### PR TITLE
fix: history랑 sell list 페이지가 페이지네이션 되지 않아요

### DIFF
--- a/src/apis/auctions/useGetHistory.ts
+++ b/src/apis/auctions/useGetHistory.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { ProductHistorySchema } from '@/schema/action';
 import type { PaginationRequestSchema } from '@/schema/pagination';
+import { convertCamelObjToKebab } from '@/utils/string';
 
 import { get } from '..';
 
@@ -15,7 +16,9 @@ interface GetHistoryResponse {
 }
 
 const getHistory = async <T = GetHistoryResponse>(request?: GetHistoryRequest): Promise<T> =>
-  get('/auctions/products/histories', { params: request });
+  get('/auctions/products/histories', {
+    params: request ? convertCamelObjToKebab(request) : undefined,
+  });
 
 export const getHistoryQueryKey = (request?: GetHistoryRequest) => ['history', request];
 

--- a/src/apis/auctions/useGetMyProduct.ts
+++ b/src/apis/auctions/useGetMyProduct.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { ProductSchema } from '@/schema/action';
 import type { PaginationRequestSchema, PaginationSchema } from '@/schema/pagination';
-import { convertCamelObjToSnake } from '@/utils/string';
+import { convertCamelObjToKebab } from '@/utils/string';
 
 import { get } from '..';
 
@@ -18,7 +18,7 @@ export const getMyProductsQueryKey = (request?: GetMyProductRequest) => ['my', '
 
 const getMyProducts = async <T = GetMyProductResponse>(request?: GetMyProductRequest): Promise<T> =>
   get('/auctions/products/users', {
-    params: request ? convertCamelObjToSnake(request) : undefined,
+    params: request ? convertCamelObjToKebab(request) : undefined,
   });
 
 /**

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -8,7 +8,7 @@ function Pagination(props: { currentPage: number; onSetPage: (page: number) => v
     return new Array(10)
       .fill(undefined)
       .map((_, idx) => start + idx)
-      .filter((page) => page <= props.totalPages);
+      .filter((page) => page < props.totalPages);
   };
 
   return (

--- a/src/pages/shop/SellListSection/index.tsx
+++ b/src/pages/shop/SellListSection/index.tsx
@@ -17,7 +17,9 @@ function SellListSection() {
   const [currentPage, setCurrentPage] = useState(0);
 
   const { data } = useGetMyProducts<{ products: ProductType<'EDIT'>[]; pagination: PaginationSchema }>(
-    {},
+    {
+      pageNumber: currentPage,
+    },
     {
       select: (data) => ({
         ...data,


### PR DESCRIPTION
# 💡 기능
- pagination 기능이 infinity scroll -> pagination 방식으로 변경되며, pagination에 필요한 api request가 `page_number` -> `page-number`로 변경되었는데 이를 수정해주지 않아서 발생
- `convertCamelObjToSnake` util -> `convertCamelToKebab` util로 변경
- 2페이지만 있는데도 불구하고, 1~3까지 페이지네이션 넘버가 보이는 문제가 있어 로직 수정